### PR TITLE
Teamtailor had issues with pointing to the correct careersite

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ If you want it first in the stack:
   Rails.configuration.middleware.insert_before 0, RequestQueueTime::Middleware
 ```
 
-If you want to use it like it is in the railtie:
-```rb
-  Rails.configuration.middleware.insert_before Rack::Runtime, RequestQueueTime::Middleware
-```
-
 The following is required for the sidekiq portion to work though:
 <!-- And add the following to the application reloader: -->
 

--- a/lib/request_queue_time/railtie.rb
+++ b/lib/request_queue_time/railtie.rb
@@ -1,7 +1,7 @@
 module RequestQueueTime
   class Railtie < Rails::Railtie
     initializer "RequestQueueTime.request_middleware" do |app|
-      app.middleware.insert_before Rack::Runtime, RequestQueueTime::Middleware
+      app.middleware.insert_after 0, RequestQueueTime::Middleware
     end
   end
 end


### PR DESCRIPTION
Because the section io host middleware ended up too far down the stack after the change.

So we have had to move up the request queue middleware to the top of the stack.