### PR TITLE
Let SidekiqReporter publish zero for required-but-empty queues

### DIFF
--- a/lib/request_queue_time/middleware/version.rb
+++ b/lib/request_queue_time/middleware/version.rb
@@ -1,5 +1,5 @@
 module RequestQueueTime
   class Middleware
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/lib/services/auto_scaling_metrics/sidekiq_reporter.rb
+++ b/lib/services/auto_scaling_metrics/sidekiq_reporter.rb
@@ -1,23 +1,31 @@
 module RequestQueueTime
   module AutoScalingMetrics
     class SidekiqReporter
-      def self.enable
+      # `required_queues` lists queue names that must always publish a datapoint,
+      # even when Redis has no entry for them. Without this, a queue with a
+      # CloudWatch autoscaling policy that never enqueues sits permanently in
+      # INSUFFICIENT_DATA, blocking scale-in for the whole service.
+      def self.enable(required_queues: [])
         Sidekiq.configure_server do |config|
           config.on(:leader) do
             AutoScalingMetrics::Reporter.start do |reporter|
-              reporter.collector = method(:collect_metrics)
+              reporter.collector = -> { collect_metrics(required_queues) }
             end
           end
         end
       end
 
-      def self.collect_metrics
-        Sidekiq::Queue.all.each do |queue|
+      def self.collect_metrics(required_queues = [])
+        live_queues = Sidekiq::Queue.all.to_h { |q| [q.name, q] }
+        names = (required_queues + live_queues.keys).uniq
+
+        names.each do |name|
+          queue = live_queues[name]
           AutoScalingMetrics::Reporter.add_metric(
             metric_name: "sidekiq_queue_latency",
-            value: queue.paused? ? 0 : queue.latency,
+            value: (queue.nil? || queue.paused?) ? 0 : queue.latency,
             unit: "Seconds",
-            dimensions: [{name: "queue_name", value: queue.name}]
+            dimensions: [{name: "queue_name", value: name}]
           )
         end
       end

--- a/spec/services/sidekiq_reporter_spec.rb
+++ b/spec/services/sidekiq_reporter_spec.rb
@@ -8,9 +8,24 @@ RSpec.describe RequestQueueTime::AutoScalingMetrics::SidekiqReporter do
       expect(Sidekiq).to receive(:configure_server).and_yield(config = double)
       expect(config).to receive(:on).with(:leader).and_yield
       expect(RequestQueueTime::AutoScalingMetrics::Reporter).to receive(:start).and_yield(reporter = double)
-      expect(reporter).to receive(:collector=).with(described_class.method(:collect_metrics))
+      expect(reporter).to receive(:collector=).with(an_instance_of(Proc))
 
       described_class.enable
+    end
+
+    it "passes required_queues through to the collector" do
+      expect(Sidekiq).to receive(:configure_server).and_yield(config = double)
+      expect(config).to receive(:on).with(:leader).and_yield
+      collector = nil
+      allow(RequestQueueTime::AutoScalingMetrics::Reporter).to receive(:start).and_yield(reporter = double)
+      allow(reporter).to receive(:collector=) { |c| collector = c }
+
+      described_class.enable(required_queues: %w[critical within_3_hours])
+
+      allow(Sidekiq::Queue).to receive(:all).and_return([])
+      expect(described_class).to receive(:collect_metrics).with(%w[critical within_3_hours]).and_call_original
+      expect(RequestQueueTime::AutoScalingMetrics::Reporter).to receive(:add_metric).twice
+      collector.call
     end
   end
 
@@ -41,6 +56,40 @@ RSpec.describe RequestQueueTime::AutoScalingMetrics::SidekiqReporter do
       )
 
       described_class.collect_metrics
+    end
+
+    it "emits 0 for required_queues that are absent from Redis" do
+      live = double(name: "default", latency: 5, paused?: false)
+      allow(Sidekiq::Queue).to receive(:all).and_return([live])
+
+      expect(RequestQueueTime::AutoScalingMetrics::Reporter).to receive(:add_metric).with(
+        metric_name: "sidekiq_queue_latency",
+        value: 5,
+        unit: "Seconds",
+        dimensions: [{name: "queue_name", value: "default"}]
+      )
+      expect(RequestQueueTime::AutoScalingMetrics::Reporter).to receive(:add_metric).with(
+        metric_name: "sidekiq_queue_latency",
+        value: 0,
+        unit: "Seconds",
+        dimensions: [{name: "queue_name", value: "within_3_hours"}]
+      )
+
+      described_class.collect_metrics(%w[default within_3_hours])
+    end
+
+    it "deduplicates when a required queue is also live" do
+      live = double(name: "critical", latency: 2, paused?: false)
+      allow(Sidekiq::Queue).to receive(:all).and_return([live])
+
+      expect(RequestQueueTime::AutoScalingMetrics::Reporter).to receive(:add_metric).once.with(
+        metric_name: "sidekiq_queue_latency",
+        value: 2,
+        unit: "Seconds",
+        dimensions: [{name: "queue_name", value: "critical"}]
+      )
+
+      described_class.collect_metrics(%w[critical])
     end
   end
 end


### PR DESCRIPTION
`SidekiqReporter` iterates `Sidekiq::Queue.all`, so a queue that has never been enqueued on a given shard is silently absent from CloudWatch. When that queue has a per-queue target-tracking autoscaling policy, its scale-in alarm sits permanently in `INSUFFICIENT_DATA` and the whole ECS service stops scaling in.

## What does this PR do?

- Adds an optional `required_queues:` kwarg to `SidekiqReporter.enable`. Defaults to `[]`, so existing consumers behave exactly as before.
- Collector now iterates `(required_queues + Sidekiq::Queue.all.keys).uniq` and emits `0` for any `required_queues` entry not present in Redis. `paused?` behavior is preserved for live queues.
- Bumps to **0.3.0** (additive public API change).

## Note

Consumer-side change for the Teamtailor monorepo: bump the gem and pass `required_queues: QUEUES_WITH_AUTOSCALING_POLICY` from `config/initializers/03_sidekiq.rb`. Follow-up PR.

<details>
<summary>📖 Description for AI review</summary>

## Context

ECS Fargate Sidekiq services on Teamtailor autoscale via per-queue CloudWatch target-tracking policies on the custom metric `sidekiq_queue_latency` (namespace `Teamtailor/queue_times`). Each queue has its own latency target (`critical` 1s, `default` 30s, `import`/`low`/`mailers_low`/`within_1_hour`/`within_3_hours` 300s, etc.).

AWS target-tracking only scales in when every policy can confirm it's safe. Verified on `eu-cyan-sidekiq-main` (2026-06-22): the publisher emitted 13 queues but never `within_3_hours` (that shard never enqueues to it), so its scale-in alarm sat in `INSUFFICIENT_DATA` and the service ratcheted from 1 to 5 tasks over weeks with zero scale-in events between spikes. Roughly $800/mo in waste across low-traffic shards.

## What was added

- `required_queues:` kwarg on `SidekiqReporter.enable`. The collector lambda closes over it and passes it through to `collect_metrics`.
- `collect_metrics(required_queues = [])`: keeps zero-arg backwards compatibility, walks the dedup'd union of `required_queues` and `Sidekiq::Queue.all`, defaulting absent queues to `0`. Preserves the existing `paused? ? 0 : latency` rule for live queues.
- Spec coverage: existing zero-arg tests preserved; new tests cover the required-queue plumbing through `.enable`, missing-queue zero emission, and dedup when a required queue is also live.

## What was intentionally left out

- The canonical queue list itself stays out of the gem. It's deployment-specific (which queues have policies depends on the infrastructure config), so passing it in from the consumer keeps the gem decoupled.
- No CHANGELOG.md entry (none exists in this repo today).

## Key constraints to verify

- Calling `.enable` without `required_queues:` must behave exactly as in 0.2.0. The default `[]` plus the dedup'd union ensures this.
- The minor-version bump (0.2.0 to 0.3.0) reflects the new public kwarg without breaking the old surface.

</details>
